### PR TITLE
Challenge 1: Implement inventory filtering by dates

### DIFF
--- a/interview/inventory/tests/test_inventory_created_after.py
+++ b/interview/inventory/tests/test_inventory_created_after.py
@@ -1,0 +1,59 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.utils import timezone
+from datetime import timedelta
+from interview.inventory.models import Inventory, InventoryLanguage, InventoryTag, InventoryType
+
+class InventoryCreatedAfterListViewTests(APITestCase):
+    def setUp(self):
+        # Create related models required for Inventory
+        self.type = InventoryType.objects.create(name="Type1")
+        self.language = InventoryLanguage.objects.create(name="English")
+        self.tag = InventoryTag.objects.create(name="Tag1")
+
+        # Create inventory items at different created_at times
+        self.old_inventory = Inventory.objects.create(
+            name="Old Inventory",
+            type=self.type,
+            language=self.language,
+            metadata={"year": 2020, "actors": ["A"], "imdb_rating": 7.5, "rotten_tomatoes_rating": 80}
+        )
+        self.old_inventory.tags.add(self.tag)
+        self.old_inventory.created_at = timezone.now() - timedelta(days=10)
+        self.old_inventory.save()
+
+        self.new_inventory = Inventory.objects.create(
+            name="New Inventory",
+            type=self.type,
+            language=self.language,
+            metadata={"year": 2024, "actors": ["B"], "imdb_rating": 8.3, "rotten_tomatoes_rating": 90}
+        )
+        self.new_inventory.tags.add(self.tag)
+        self.new_inventory.created_at = timezone.now() - timedelta(days=1)
+        self.new_inventory.save()
+
+    def test_inventory_created_after_filter(self):
+        url = reverse('inventory-created-after-list')
+        filter_date = (timezone.now() - timedelta(days=5)).isoformat()
+        response = self.client.get(url, {'created_after': filter_date})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()
+        #Should only contain new inventory
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['name'], 'New Inventory')
+
+    def test_missing_created_after_param(self):
+        url= reverse('inventory-created-after-list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.json())
+
+    def test_invalid_created_after_param(self):
+        url = reverse('inventory-created-after-list')
+        response = self.client.get(url, {'created_after': 'invalid-date'})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.json())

--- a/interview/inventory/urls.py
+++ b/interview/inventory/urls.py
@@ -1,6 +1,6 @@
 
 from django.urls import path
-from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView
+from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView, InventoryCreatedAfterListView
 from interview.order.views import OrderListCreateView, OrderTagListCreateView
 
 
@@ -13,4 +13,5 @@ urlpatterns = [
     path('tags/', InventoryTagListCreateView.as_view(), name='inventory-tags-list'),
     path('types/', InventoryTypeListCreateView.as_view(), name='inventory-types-list'),
     path('', InventoryListCreateView.as_view(), name='inventory-list'),
+    path('created-after/', InventoryCreatedAfterListView.as_view(), name='inventory-created-after-list'),
 ]

--- a/interview/inventory/views.py
+++ b/interview/inventory/views.py
@@ -1,3 +1,4 @@
+from django.utils.dateparse import parse_datetime
 from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework.views import APIView
@@ -219,3 +220,19 @@ class InventoryTypeRetrieveUpdateDestroyView(APIView):
     
     def get_queryset(self, **kwargs):
         return self.queryset.get(**kwargs)
+
+
+class InventoryCreatedAfterListView(APIView):
+    serializer_class = InventorySerializer
+
+    def get(self, request: Request, *args, **kwags) -> Response:
+        created_after = request.query_params.get('created_after')
+        if not created_after:
+            return Response({'error': 'created_after query parameter is required'}, status=400)
+        
+        dt = parse_datetime(created_after)
+        if not dt:
+            return Response({'error': 'Invalid datetime format for created_after'}, status=400)
+        queryset = Inventory.objects.filter(created_at__gt=dt)
+        serializer = self.serializer_class(queryset, many=True)
+        return Response(serializer.data, status=200)


### PR DESCRIPTION
- Implemented Challenge #1: Inventory 'created_after' filter
- Adds endpoint to list Inventory items created after a specific datetime
- Endpoint - '/inventory/created-after/'
- Example - http://127.0.0.1:8000/inventory/created-after/?created_after=2000-02-01T00:00:00Z

- Created 3 test cases in 'test_inventory_created_after.py'
- Tests cover:
    - Valid datetime filter
    -  Missing 'created_after' param
    -  Invalid datetime format
  - Ran all test cases