### PR TITLE
Challenge-2-deactivate-order

### DIFF
--- a/interview/order/tests/test_order_deactivate.py
+++ b/interview/order/tests/test_order_deactivate.py
@@ -1,0 +1,54 @@
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.urls import reverse
+
+from interview.inventory.models import Inventory, InventoryType, InventoryLanguage
+from interview.order.models import Order, OrderTag
+from django.utils import timezone
+from datetime import timedelta
+
+
+class DeactivateOrderViewTests(APITestCase):
+    def setUp(self):
+        # Create dependencies for Inventory and Order
+        inventory_type = InventoryType.objects.create(name="Type1")
+        inventory_language = InventoryLanguage.objects.create(name="English")
+        inventory = Inventory.objects.create(
+            name="Test Inventory",
+            type=inventory_type,
+            language=inventory_language,
+            metadata={"year": 2022}
+        )
+        tag = OrderTag.objects.create(name="Test Tag")
+
+        self.order = Order.objects.create(
+            inventory=inventory,
+            start_date=timezone.now().date(),
+            embargo_date=(timezone.now() + timedelta(days=30)).date()
+        )
+        self.order.tags.add(tag)
+
+        self.deactivate_url = reverse('order-deactivate', args=[self.order.id])
+
+    def test_deactivate_active_order(self):
+        response = self.client.post(self.deactivate_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['detail'], 'Order deactivated successfully.')
+
+        # Verify from DB
+        self.order.refresh_from_db()
+        self.assertFalse(self.order.is_active)
+
+    def test_deactivate_already_inactive_order(self):
+        # Manually deactivate
+        self.order.is_active = False
+        self.order.save()
+
+        response = self.client.post(self.deactivate_url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()['detail'], 'Order is already inactive.')
+
+    def test_deactivate_non_existent_order(self):
+        invalid_url = reverse('order-deactivate', args=[9999])
+        response = self.client.post(invalid_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -1,10 +1,10 @@
 
 from django.urls import path
-from interview.order.views import OrderListCreateView, OrderTagListCreateView
+from interview.order.views import OrderListCreateView, OrderTagListCreateView, DeactivateOrderView
 
 
 urlpatterns = [
     path('tags/', OrderTagListCreateView.as_view(), name='order-detail'),
     path('', OrderListCreateView.as_view(), name='order-list'),
-
+    path('<int:pk>/deactivate/', DeactivateOrderView.as_view(), name='order-deactivate'),
 ]

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -1,5 +1,7 @@
-from django.shortcuts import render
-from rest_framework import generics
+from django.shortcuts import get_object_or_404
+from rest_framework import generics, status
+from rest_framework.views import APIView
+from rest_framework.response import Response
 
 from interview.order.models import Order, OrderTag
 from interview.order.serializers import OrderSerializer, OrderTagSerializer
@@ -13,3 +15,22 @@ class OrderListCreateView(generics.ListCreateAPIView):
 class OrderTagListCreateView(generics.ListCreateAPIView):
     queryset = OrderTag.objects.all()
     serializer_class = OrderTagSerializer
+
+
+class DeactivateOrderView(APIView):
+    def post(self, request, pk):
+        order = get_object_or_404(Order, pk=pk)
+
+        if not order.is_active:
+            return Response(
+                {"detail": "Order is already inactive."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        order.is_active = False
+        order.save()
+
+        return Response(
+            {"detail": "Order deactivated successfully."},
+            status=status.HTTP_200_OK
+        )


### PR DESCRIPTION
Implemented Challenge https://github.com/divya0708/value_labs_tmt_insights_assignment/pull/2: DeactivateOrderView to see is_active  state on an order 

This PR implements the DeactivateOrderView, which allows deactivating an existing order by setting its is_active flag to False. This endpoint ensures that only active orders can be deactivated and returns appropriate error responses for already inactive or non-existent orders.

Endpoint - POST /orders/<int:pk>/deactivate/


Created 3 test cases in 'test_order_deactivate.py'

Tests cover:

Successful deactivation of an active order.
Handling of already inactive orders.
Handling of non-existent orders.

Ran all test cases