### PR TITLE
Challenge-5-inventory-pagination

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,0 +1,16 @@
+from .base import *
+
+DEBUG = False
+
+ALLOWED_HOSTS = ['*']
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'prod_db_name',
+        'USER': 'prod_user',
+        'PASSWORD': 'prod_password',
+        'HOST': 'prod_db_host',
+        'PORT': '5432',
+    }
+}

--- a/interview/inventory/pagination.py
+++ b/interview/inventory/pagination.py
@@ -1,0 +1,7 @@
+# interview/inventory/pagination.py
+
+from rest_framework.pagination import LimitOffsetPagination
+
+class InventoryLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 3
+    max_limit = 10

--- a/interview/inventory/tests/test_inventory_pagination.py
+++ b/interview/inventory/tests/test_inventory_pagination.py
@@ -1,0 +1,42 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from interview.inventory.models import Inventory, InventoryLanguage, InventoryType
+
+class InventoryListViewPaginationTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+        # Required related objects
+        self.language = InventoryLanguage.objects.create(name="English")
+        self.inventory_type = InventoryType.objects.create(name="Book")
+
+        # Create 5 inventory items
+        for i in range(5):
+            Inventory.objects.create(
+                name=f"Item {i+1}",
+                metadata={
+                    "language_id": self.language.id,
+                    "tag_ids": [],
+                    "type_id": self.inventory_type.id
+                },
+                language=self.language,
+                type=self.inventory_type
+            )
+
+    def test_inventory_list_pagination_limit_3(self):
+        response = self.client.get('/inventory/', {'limit': 3, 'offset': 0})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        # Pagination structure
+        self.assertIn('results', data)
+        self.assertIn('count', data)
+        self.assertIn('next', data)
+        self.assertIn('previous', data)
+
+        # Only 3 items returned
+        self.assertEqual(len(data['results']), 3)
+        self.assertEqual(data['count'], 5)
+        self.assertIsNotNone(data['next'])
+        self.assertIsNone(data['previous'])

--- a/interview/inventory/views.py
+++ b/interview/inventory/views.py
@@ -6,11 +6,14 @@ from rest_framework.views import APIView
 from interview.inventory.models import Inventory, InventoryLanguage, InventoryTag, InventoryType
 from interview.inventory.schemas import InventoryMetaData
 from interview.inventory.serializers import InventoryLanguageSerializer, InventorySerializer, InventoryTagSerializer, InventoryTypeSerializer
+from interview.inventory.pagination import InventoryLimitOffsetPagination
 
 
 class InventoryListCreateView(APIView):
     queryset = Inventory.objects.all()
     serializer_class = InventorySerializer
+    pagination_class = InventoryLimitOffsetPagination
+
     
     def post(self, request: Request, *args, **kwargs) -> Response:
         try:
@@ -28,9 +31,11 @@ class InventoryListCreateView(APIView):
         return Response(serializer.data, status=201)
     
     def get(self, request: Request, *args, **kwargs) -> Response:
-        serializer = self.serializer_class(self.get_queryset(), many=True)
-        
-        return Response(serializer.data, status=200)
+        queryset = self.get_queryset()
+        paginator = InventoryLimitOffsetPagination()
+        paginated_qs = paginator.paginate_queryset(queryset, request)
+        serializer = self.serializer_class(paginated_qs, many=True)
+        return paginator.get_paginated_response(serializer.data)
     
     def get_queryset(self):
         return self.queryset.all()


### PR DESCRIPTION
Implemented Challenge https://github.com/divya0708/value_labs_tmt_insights_assignment/pull/5: Added pagination to InventoryListView that displays 3 items per request

This PR implements pagination for the InventoryListView using Django REST Framework's LimitOffsetPagination.
Added custom pagination class InventoryLimitOffsetPagination:
   - default_limit set to 3 as per assignment requirement
   - max_limit set to 10 to enforce sensible upper bounds on query size
Ensures pagination via ?limit=X&offset=Y query parameters
Updated InventoryListView to use the custom pagination class

Endpoint - GET /inventory/?limit=3&offset=0

Created 1 test cases in 'test_inventory_pagination.py'

Tests cover:

Response structure (pagination keys: count, next, previous, results)
Pagination returns correct number of items and respects limit

Ran all test cases