### PR TITLE
Challenge 6:List all tags for an order

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,16 +1,19 @@
 from .base import *
 
+# Disable debug mode for production
 DEBUG = False
 
+# Replace '*' with actual production domain(s) or IPs for security
 ALLOWED_HOSTS = ['*']
 
+# PostgreSQL production database configuration
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'prod_db_name',
-        'USER': 'prod_user',
-        'PASSWORD': 'prod_password',
-        'HOST': 'prod_db_host',
-        'PORT': '5432',
+        'NAME': 'prod_db_name',     # Replace with production DB name
+        'USER': 'prod_user',        # Replace with production DB user
+        'PASSWORD': 'prod_password',# Replace with production DB password
+        'HOST': 'prod_db_host',     # Replace with production DB host
+        'PORT': '5432',             # Default PostgreSQL port
     }
 }

--- a/interview/order/tests/test_order_date_range.py
+++ b/interview/order/tests/test_order_date_range.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from datetime import timedelta
 
 from interview.order.models import Order, OrderTag
-from interview.inventory.models import Inventory, InventoryLanguage, InventoryTag, InventoryType
+from interview.inventory.models import Inventory, InventoryLanguage, InventoryType
 
 
 class OrderDateRangeListViewTests(APITestCase):
@@ -16,7 +16,7 @@ class OrderDateRangeListViewTests(APITestCase):
         # Setup related models
         self.type = InventoryType.objects.create(name="Type1")
         self.language = InventoryLanguage.objects.create(name="English")
-        self.tag = OrderTag.objects.create(name="Tag1")  # <-- Use OrderTag here
+        self.tag = OrderTag.objects.create(name="Tag1")
 
         # Inventories
         self.inventory1 = Inventory.objects.create(

--- a/interview/order/tests/test_order_tags_list.py
+++ b/interview/order/tests/test_order_tags_list.py
@@ -1,0 +1,74 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from interview.order.models import Order, OrderTag
+from interview.inventory.models import Inventory, InventoryLanguage, InventoryType
+from django.utils import timezone
+from datetime import timedelta
+
+class OrderTagsListViewTest(APITestCase):
+    def setUp(self):
+        # Create Inventory related models
+        self.inventory_type = InventoryType.objects.create(name="Book")
+        self.language = InventoryLanguage.objects.create(name="English")
+
+        # Create some OrderTags
+        self.tag1 = OrderTag.objects.create(name="Urgent")
+        self.tag2 = OrderTag.objects.create(name="Gift")
+
+        # Create Inventory instance
+        self.inventory = Inventory.objects.create(
+            name="Sample Inventory",
+            type=self.inventory_type,
+            language=self.language,
+            metadata={"info": "sample"}
+        )
+
+        # Create Orders and assign tags
+        self.order1 = Order.objects.create(
+            inventory=self.inventory,
+            start_date=timezone.now().date(),
+            embargo_date=timezone.now().date() + timedelta(days=5),
+            is_active=True,
+        )
+        self.order1.tags.add(self.tag1)
+
+        self.order2 = Order.objects.create(
+            inventory=self.inventory,
+            start_date=timezone.now().date(),
+            embargo_date=timezone.now().date() + timedelta(days=10),
+            is_active=True,
+        )
+        self.order2.tags.add(self.tag2)
+
+    def test_list_order_tags(self):
+        url = reverse('order-tags-list', kwargs={'pk': self.order1.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tags = response.json()
+        tag_names = [tag['name'] for tag in tags]
+        self.assertIn(self.tag1.name, tag_names)
+        self.assertNotIn(self.tag2.name, tag_names)
+
+        # Also check order2 tags
+        url = reverse('order-tags-list', kwargs={'pk': self.order2.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tags = response.json()
+        tag_names = [tag['name'] for tag in tags]
+        self.assertIn(self.tag2.name, tag_names)
+        self.assertNotIn(self.tag1.name, tag_names)
+
+    def test_list_order_tags_no_tags(self):
+        self.order1.tags.clear()
+        self.order2.tags.clear()
+
+        url = reverse('order-tags-list', kwargs={'pk': self.order1.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
+        url = reverse('order-tags-list', kwargs={'pk': self.order2.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])

--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -1,6 +1,6 @@
 
 from django.urls import path
-from interview.order.views import OrderListCreateView, OrderTagListCreateView, DeactivateOrderView, OrderDateRangeListView
+from interview.order.views import OrderListCreateView, OrderTagListCreateView, DeactivateOrderView, OrderDateRangeListView, OrderTagsListView
 
 
 urlpatterns = [
@@ -8,4 +8,5 @@ urlpatterns = [
     path('', OrderListCreateView.as_view(), name='order-list'),
     path('<int:pk>/deactivate/', DeactivateOrderView.as_view(), name='order-deactivate'),
     path('date-range/', OrderDateRangeListView.as_view(), name = 'order-date-range-list'),
+    path('<int:pk>/tags/', OrderTagsListView.as_view(), name='order-tags-list'),
 ]

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -56,3 +56,11 @@ class OrderDateRangeListView(generics.ListAPIView):
         
         # Filter orders where start_date >= provided start_date AND embargo_date <= provided embargo_date
         return Order.objects.filter(start_date__gte=start_date, embargo_date__lte=embargo_date)
+    
+
+class OrderTagsListView(generics.ListAPIView):
+    serializer_class = OrderTagSerializer
+
+    def get_queryset(self):
+        order = get_object_or_404(Order, pk=self.kwargs["pk"])
+        return order.tags.all()


### PR DESCRIPTION
Implemented Challenge https://github.com/divya0708/value_labs_tmt_insights_assignment/pull/6: Created endpoint that lists all tags associated with an order

This PR implements an endpoint to list all tags associated with a specific order.

Added a new API view OrderTagsListView to return all tags linked to a given order ID.
Endpoint - /orders/<order_id>/tags/

Created 2 test cases in 'test_order_tags_list.py'
Tests cover:

Successful retrieval of tags for an order.
Handling of orders with no tags.

Ran all test cases