### PR TITLE
Challenge 7: All orders associated with a tag

### DIFF
--- a/interview/order/tests/test_orders_by_tag.py
+++ b/interview/order/tests/test_orders_by_tag.py
@@ -1,0 +1,48 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from interview.order.models import Order, OrderTag
+from interview.inventory.models import Inventory, InventoryLanguage, InventoryType
+from django.utils import timezone
+from datetime import timedelta
+
+class OrdersByTagListViewTest(APITestCase):
+    def setUp(self):
+        # Setup inventory
+        inventory_type = InventoryType.objects.create(name="Book")
+        language = InventoryLanguage.objects.create(name="English")
+        inventory = Inventory.objects.create(name="Sample", type=inventory_type, language=language, metadata={})
+
+        # Setup tags
+        self.tag1 = OrderTag.objects.create(name="Urgent")
+        self.tag2 = OrderTag.objects.create(name="Normal")
+
+        # Setup orders
+        self.order1 = Order.objects.create(
+            inventory=inventory,
+            start_date=timezone.now().date(),
+            embargo_date=timezone.now().date() + timedelta(days=5),
+            is_active=True,
+        )
+        self.order1.tags.add(self.tag1)
+
+        self.order2 = Order.objects.create(
+            inventory=inventory,
+            start_date=timezone.now().date(),
+            embargo_date=timezone.now().date() + timedelta(days=10),
+            is_active=True,
+        )
+        self.order2.tags.add(self.tag2)
+
+    def test_orders_filtered_by_tag(self):
+        url = reverse('orders-by-tag-list', kwargs={'tag_id': self.tag1.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['id'], self.order1.id)
+
+    def test_orders_by_nonexistent_tag(self):
+        url = reverse('orders-by-tag-list', kwargs={'tag_id': 9999})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -1,6 +1,6 @@
 
 from django.urls import path
-from interview.order.views import OrderListCreateView, OrderTagListCreateView, DeactivateOrderView, OrderDateRangeListView
+from interview.order.views import OrderListCreateView, OrderTagListCreateView, DeactivateOrderView, OrderDateRangeListView, OrdersByTagListView
 
 
 urlpatterns = [
@@ -8,4 +8,5 @@ urlpatterns = [
     path('', OrderListCreateView.as_view(), name='order-list'),
     path('<int:pk>/deactivate/', DeactivateOrderView.as_view(), name='order-deactivate'),
     path('date-range/', OrderDateRangeListView.as_view(), name = 'order-date-range-list'),
+    path('tags/<int:tag_id>/orders/', OrdersByTagListView.as_view(), name='orders-by-tag-list'),
 ]

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -56,3 +56,12 @@ class OrderDateRangeListView(generics.ListAPIView):
         
         # Filter orders where start_date >= provided start_date AND embargo_date <= provided embargo_date
         return Order.objects.filter(start_date__gte=start_date, embargo_date__lte=embargo_date)
+    
+
+class OrdersByTagListView(generics.ListAPIView):
+    serializer_class = OrderSerializer
+
+    def get_queryset(self):
+        tag_id = self.kwargs.get('tag_id')
+        tag = get_object_or_404(OrderTag, pk=tag_id)
+        return tag.orders.all()


### PR DESCRIPTION
Implemented Challenge https://github.com/divya0708/value_labs_tmt_insights_assignment/pull/7: Created endpoint that lists all the orders associated with a particular tag.
Implemented a new API endpoint that returns all orders associated with a specific tag. This allows to filter orders based on assigned tags, improving data retrieval and filtering capabilities.


Endpoint - /orders/tags/<int:tag_id>/orders/

Created 2 test cases in 'test_orders_by_tag.py'

Tests cover:


Successful retrieval of orders by tag
Handling non-existent tags (404 response)

Ran all test cases